### PR TITLE
main.scss

### DIFF
--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -784,6 +784,7 @@ and (max-device-width : 568px) {
         h1 {
             margin-top: 20px;
             margin-bottom: 0px;
+            font-size:24px;
         }
         .partners-header {
             margin-bottom: 20px;


### PR DESCRIPTION
Уменьшил размер шрифта h1 для модальных окон, так как не влезало название партнера (строка 787). Сделал размер 24px.